### PR TITLE
remove key buttons for mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
           </section>
         </div>
         <section
-          class="flex flex-col items-center justify-center gap-4 duration-300 ease-linear"
+          class="flex-col items-center justify-center hidden gap-4 duration-300 ease-linear md:flex"
         >
           <div class="row">
             <button class="key">q</button>

--- a/style.css
+++ b/style.css
@@ -8,11 +8,11 @@
   }
 
   .key {
-    @apply w-8 text-xl duration-300 ease-in-out bg-gray-900 rounded-md shadow-lg shadow-gray-700 sm:w-10 sm:text-2xl md:w-12 md:text-3xl aspect-square text-gray-50 active:shadow-md;
+    @apply w-10 text-xl duration-300 ease-in-out bg-gray-900 border-4 border-gray-900 rounded-sm sm:w-10 sm:text-2xl md:w-14 md:text-3xl aspect-square text-gray-50 hover:bg-gray-300 hover:text-gray-900;
   }
 
   .row {
-    @apply flex flex-wrap justify-center gap-2 md:gap-4 lg:gap-4;
+    @apply flex flex-wrap items-center justify-center gap-4;
   }
 
   .letter {


### PR DESCRIPTION
Originally key buttons shows on mobile layout. Due to the size of real estate of mobile screen, key buttons will stay hidden until the screen is larger than 786px